### PR TITLE
Fix language paths and register cache services

### DIFF
--- a/administrator/components/com_contentintegrator/contentintegrator.php
+++ b/administrator/components/com_contentintegrator/contentintegrator.php
@@ -4,8 +4,10 @@
 use Joomla\CMS\Factory;
 use Joomla\CMS\Dispatcher\ComponentDispatcherFactoryInterface;
 use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
+use Joomla\CMS\Cache\CacheControllerFactoryInterface;
 use Joomla\CMS\Extension\Service\Provider\ComponentDispatcherFactory;
 use Joomla\CMS\Extension\Service\Provider\MVCFactory;
+use Joomla\CMS\Extension\Service\Provider\CacheControllerFactory;
 
 $container = Factory::getContainer();
 $ns        = 'Joomla\\Component\\Contentintegrator';
@@ -16,6 +18,10 @@ if (!$container->has(ComponentDispatcherFactoryInterface::class)) {
 
 if (!$container->has(MVCFactoryInterface::class)) {
     $container->registerServiceProvider(new MVCFactory($ns));
+}
+
+if (!$container->has(CacheControllerFactoryInterface::class)) {
+    $container->registerServiceProvider(new CacheControllerFactory);
 }
 
 echo $container

--- a/administrator/components/com_contentintegrator/services/provider.php
+++ b/administrator/components/com_contentintegrator/services/provider.php
@@ -6,6 +6,7 @@ namespace Joomla\Component\Contentintegrator\Administrator\Service;
 use Joomla\CMS\Extension\Service\Provider\ComponentDispatcherFactory;
 use Joomla\CMS\Extension\Service\Provider\MVCFactory;
 use Joomla\CMS\Extension\Service\Provider\RouterFactory;
+use Joomla\CMS\Extension\Service\Provider\CacheControllerFactory;
 use Joomla\DI\Container;
 use Joomla\DI\ServiceProviderInterface;
 
@@ -18,5 +19,6 @@ class Provider implements ServiceProviderInterface
         $container->registerServiceProvider(new ComponentDispatcherFactory($ns));
         $container->registerServiceProvider(new MVCFactory($ns));
         $container->registerServiceProvider(new RouterFactory($ns));
+        $container->registerServiceProvider(new CacheControllerFactory);
     }
 }

--- a/com_contentintegrator.xml
+++ b/com_contentintegrator.xml
@@ -13,11 +13,11 @@
             <folder>src</folder>
         </files>
         <config>config.xml</config>
-        <languages folder="language">
-            <language tag="en-GB">en-GB/en-GB.com_contentintegrator.ini</language>
-            <language tag="en-GB">en-GB/en-GB.com_contentintegrator.sys.ini</language>
-            <language tag="de-DE">de-DE/de-DE.com_contentintegrator.ini</language>
-            <language tag="de-DE">de-DE/de-DE.com_contentintegrator.sys.ini</language>
+        <languages>
+            <language tag="en-GB">administrator/language/en-GB/en-GB.com_contentintegrator.ini</language>
+            <language tag="en-GB">administrator/language/en-GB/en-GB.com_contentintegrator.sys.ini</language>
+            <language tag="de-DE">administrator/language/de-DE/de-DE.com_contentintegrator.ini</language>
+            <language tag="de-DE">administrator/language/de-DE/de-DE.com_contentintegrator.sys.ini</language>
         </languages>
         <services>
             <service type="provider">services/provider.php</service>


### PR DESCRIPTION
## Summary
- fix manifest language paths and ensure service provider registered
- add cache controller provider and fallback registration

## Testing
- `xmllint --noout com_contentintegrator.xml`
- `php -l administrator/components/com_contentintegrator/services/provider.php`
- `php -l administrator/components/com_contentintegrator/contentintegrator.php`


------
https://chatgpt.com/codex/tasks/task_e_68905779f32883298e5cb3cabd89c23a