### PR TITLE
Register cache storage provider during installation

### DIFF
--- a/script.php
+++ b/script.php
@@ -3,13 +3,19 @@
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\LanguageHelper;
+use Joomla\CMS\Service\Provider\Cache;
 
 class com_contentintegratorInstallerScript
 {
     public function postflight($type, $parent): void
     {
         $container = Factory::getContainer();
-        $db        = $container->get('DatabaseDriver');
+
+        if (! $container->has('cache.storage')) {
+            $container->registerServiceProvider(new Cache());
+        }
+
+        $db = $container->get('DatabaseDriver');
 
         $db->setQuery("DELETE FROM #__extensions WHERE element = 'com_contentintegrator' AND type = 'component'");
         $db->execute();


### PR DESCRIPTION
## Summary
- register cache service provider in installer script to ensure cache storage service is available

## Testing
- `php -l script.php`


------
https://chatgpt.com/codex/tasks/task_e_689059fc54f0832987c5a7b808795259