### PR TITLE
Fix dispatcher creation with application instance

### DIFF
--- a/administrator/components/com_contentintegrator/contentintegrator.php
+++ b/administrator/components/com_contentintegrator/contentintegrator.php
@@ -26,5 +26,5 @@ if (!$container->has(CacheControllerFactoryInterface::class)) {
 
 echo $container
     ->get(ComponentDispatcherFactoryInterface::class)
-    ->createDispatcher('com_contentintegrator')
+    ->createDispatcher(Factory::getApplication())
     ->dispatch();


### PR DESCRIPTION
## Summary
- pass a `CMSApplicationInterface` instance to `createDispatcher`

## Testing
- `php -l administrator/components/com_contentintegrator/contentintegrator.php`
- `php verify_extension.php .` *(fails: missing language files and namespace declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68905fd1a71883298feb323682a31d27