### PR TITLE
Add default display controller for content integrator

### DIFF
--- a/administrator/components/com_contentintegrator/src/Controller/DisplayController.php
+++ b/administrator/components/com_contentintegrator/src/Controller/DisplayController.php
@@ -1,0 +1,12 @@
+<?php
+namespace Joomla\Component\ContentIntegrator\Administrator\Controller;
+
+defined('_JEXEC') or die;
+
+use Joomla\CMS\MVC\Controller\BaseController;
+
+class DisplayController extends BaseController
+{
+    protected $default_view = 'import';
+}
+


### PR DESCRIPTION
## Summary
- add DisplayController to handle default routing for com_contentintegrator

## Testing
- `php -l administrator/components/com_contentintegrator/src/Controller/DisplayController.php`


------
https://chatgpt.com/codex/tasks/task_e_689060f92c488329a62fee46e329ffb2