### PR TITLE
Remove cache service registration from ContentIntegrator

### DIFF
--- a/administrator/components/com_contentintegrator/contentintegrator.php
+++ b/administrator/components/com_contentintegrator/contentintegrator.php
@@ -4,10 +4,8 @@
 use Joomla\CMS\Factory;
 use Joomla\CMS\Dispatcher\ComponentDispatcherFactoryInterface;
 use Joomla\CMS\MVC\Factory\MVCFactoryInterface;
-use Joomla\CMS\Cache\CacheControllerFactoryInterface;
 use Joomla\CMS\Extension\Service\Provider\ComponentDispatcherFactory;
 use Joomla\CMS\Extension\Service\Provider\MVCFactory;
-use Joomla\CMS\Extension\Service\Provider\CacheControllerFactory;
 
 $container = Factory::getContainer();
 $ns        = 'Joomla\\Component\\Contentintegrator';
@@ -20,9 +18,6 @@ if (!$container->has(MVCFactoryInterface::class)) {
     $container->registerServiceProvider(new MVCFactory($ns));
 }
 
-if (!$container->has(CacheControllerFactoryInterface::class)) {
-    $container->registerServiceProvider(new CacheControllerFactory);
-}
 
 echo $container
     ->get(ComponentDispatcherFactoryInterface::class)

--- a/administrator/components/com_contentintegrator/services/provider.php
+++ b/administrator/components/com_contentintegrator/services/provider.php
@@ -6,7 +6,6 @@ namespace Joomla\Component\Contentintegrator\Administrator\Service;
 use Joomla\CMS\Extension\Service\Provider\ComponentDispatcherFactory;
 use Joomla\CMS\Extension\Service\Provider\MVCFactory;
 use Joomla\CMS\Extension\Service\Provider\RouterFactory;
-use Joomla\CMS\Extension\Service\Provider\CacheControllerFactory;
 use Joomla\DI\Container;
 use Joomla\DI\ServiceProviderInterface;
 
@@ -19,6 +18,5 @@ class Provider implements ServiceProviderInterface
         $container->registerServiceProvider(new ComponentDispatcherFactory($ns));
         $container->registerServiceProvider(new MVCFactory($ns));
         $container->registerServiceProvider(new RouterFactory($ns));
-        $container->registerServiceProvider(new CacheControllerFactory);
     }
 }


### PR DESCRIPTION
## Summary
- drop custom cache factory from component entry file
- stop registering CacheControllerFactory in provider

## Testing
- `php -l administrator/components/com_contentintegrator/contentintegrator.php`
- `php -l administrator/components/com_contentintegrator/services/provider.php`
- `xmllint --noout com_contentintegrator.xml`


------
https://chatgpt.com/codex/tasks/task_e_689088163ab88329843ac458d9ff0780