### PR TITLE
Remove cache experiment and add default dashboard

### DIFF
--- a/administrator/components/com_contentintegrator/src/Controller/DisplayController.php
+++ b/administrator/components/com_contentintegrator/src/Controller/DisplayController.php
@@ -1,12 +1,22 @@
 <?php
-namespace Joomla\Component\ContentIntegrator\Administrator\Controller;
+namespace Joomla\Component\Contentintegrator\Administrator\Controller;
 
 defined('_JEXEC') or die;
 
+use Joomla\CMS\Factory;
 use Joomla\CMS\MVC\Controller\BaseController;
 
 class DisplayController extends BaseController
 {
-    protected $default_view = 'import';
-}
+    protected $default_view = 'dashboard';
 
+    public function display($cachable = false, $urlparams = [])
+    {
+        return parent::display($cachable, $urlparams);
+    }
+
+    protected function canView($view = null)
+    {
+        return Factory::getApplication()->getIdentity()->authorise('core.manage', 'com_contentintegrator');
+    }
+}

--- a/administrator/components/com_contentintegrator/src/View/Dashboard/HtmlView.php
+++ b/administrator/components/com_contentintegrator/src/View/Dashboard/HtmlView.php
@@ -1,0 +1,10 @@
+<?php
+namespace Joomla\Component\Contentintegrator\Administrator\View\Dashboard;
+
+defined('_JEXEC') or die;
+
+use Joomla\CMS\MVC\View\HtmlView as BaseHtmlView;
+
+class HtmlView extends BaseHtmlView
+{
+}

--- a/administrator/components/com_contentintegrator/tmpl/dashboard/default.php
+++ b/administrator/components/com_contentintegrator/tmpl/dashboard/default.php
@@ -1,0 +1,4 @@
+<?php defined('_JEXEC') or die; ?>
+
+<h1 class="mb-4">Content Integrator – Dashboard</h1>
+<p>Willkommen! Wählen Sie links im Menü einen Import-Wizard.</p>

--- a/administrator/sql/install.mysql.utf8.sql
+++ b/administrator/sql/install.mysql.utf8.sql
@@ -1,0 +1,7 @@
+INSERT IGNORE INTO #__menu
+(menutype, title, alias, path, link, type, published, parent_id, component_id, access, level, language, client_id)
+VALUES ('menu', 'Content Integrator', 'content-integrator', 'content-integrator',
+        'index.php?option=com_contentintegrator', 'component', 1,
+        (SELECT id FROM #__menu WHERE title = 'Components'),
+        (SELECT extension_id FROM #__extensions WHERE element = 'com_contentintegrator'),
+        1, 2, '*', 1);

--- a/com_contentintegrator.xml
+++ b/com_contentintegrator.xml
@@ -11,6 +11,7 @@
             <filename>contentintegrator.php</filename>
             <folder>services</folder>
             <folder>src</folder>
+            <folder>tmpl</folder>
         </files>
         <config>config.xml</config>
         <languages>

--- a/script.php
+++ b/script.php
@@ -3,7 +3,6 @@
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Language\LanguageHelper;
-use Joomla\CMS\Service\Provider\Cache;
 
 class com_contentintegratorInstallerScript
 {
@@ -11,16 +10,10 @@ class com_contentintegratorInstallerScript
     {
         $container = Factory::getContainer();
 
-        if (! $container->has('cache.storage')) {
-            $container->registerServiceProvider(new Cache());
-        }
-
         $db = $container->get('DatabaseDriver');
 
         $db->setQuery("DELETE FROM #__extensions WHERE element = 'com_contentintegrator' AND type = 'component'");
         $db->execute();
-
-        $container->get('cache.storage')->cleanAll();
 
         foreach (['en-GB', 'de-DE'] as $tag) {
             LanguageHelper::loadLanguageFromFilesystem($tag, JPATH_ADMINISTRATOR);


### PR DESCRIPTION
## Summary
- remove cache provider usage from installation script
- add dashboard controller, view, and template as default
- add SQL installer script for backend menu and include tmpl folder in manifest

## Testing
- `php -l script.php && php -l administrator/components/com_contentintegrator/src/Controller/DisplayController.php && php -l administrator/components/com_contentintegrator/src/View/Dashboard/HtmlView.php && php -l administrator/components/com_contentintegrator/tmpl/dashboard/default.php`


------
https://chatgpt.com/codex/tasks/task_e_689095c271f48329bcd9e96e4d9a1a8f