### PR TITLE
refactor: use Joomla language API

### DIFF
--- a/script.php
+++ b/script.php
@@ -2,7 +2,6 @@
 \defined('_JEXEC') or die;
 
 use Joomla\CMS\Factory;
-use Joomla\CMS\Language\LanguageHelper;
 
 class com_contentintegratorInstallerScript
 {
@@ -15,8 +14,9 @@ class com_contentintegratorInstallerScript
         $db->setQuery("DELETE FROM #__extensions WHERE element = 'com_contentintegrator' AND type = 'component'");
         $db->execute();
 
+        $lang = Factory::getApplication()->getLanguage();
         foreach (['en-GB', 'de-DE'] as $tag) {
-            LanguageHelper::loadLanguageFromFilesystem($tag, JPATH_ADMINISTRATOR);
+            $lang->load('com_contentintegrator', JPATH_ADMINISTRATOR, $tag, true, true);
         }
     }
 }


### PR DESCRIPTION
## Summary
- replace deprecated `LanguageHelper::loadLanguageFromFilesystem` with `Factory::getApplication()->getLanguage()->load`

## Testing
- `php -l script.php`
- `phpcs -q --standard=PSR12 script.php` *(fails: class not in PascalCase, missing namespace, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6890df51e7cc83299076a437df692ac9