### PR TITLE
Validate sources before copying during install

### DIFF
--- a/administrator/components/com_contentintegrator/com_contentintegrator.xml
+++ b/administrator/components/com_contentintegrator/com_contentintegrator.xml
@@ -14,6 +14,7 @@
             <folder>services</folder>
             <folder>src</folder>
             <folder>tmpl</folder>
+            <folder>admin/sql</folder>
         </files>
         <config>config.xml</config>
         <languages>
@@ -32,6 +33,7 @@
     <media folder="media/com_contentintegrator" destination="com_contentintegrator">
         <folder>css</folder>
         <folder>js</folder>
+        <folder>images</folder>
     </media>
     <install>
         <sql folder="admin/sql" driver="mysql">install.mysql.utf8.sql</sql>

--- a/administrator/components/com_contentintegrator/script.php
+++ b/administrator/components/com_contentintegrator/script.php
@@ -7,6 +7,63 @@ class Com_ContentintegratorInstallerScript
 {
     public function preflight($type, $parent)
     {
+        $paths = [
+            JPATH_ADMINISTRATOR . '/components/com_contentintegrator/services',
+            JPATH_ADMINISTRATOR . '/components/com_contentintegrator/src',
+            JPATH_ADMINISTRATOR . '/components/com_contentintegrator/tmpl',
+            JPATH_ADMINISTRATOR . '/components/com_contentintegrator/admin/sql',
+            JPATH_SITE . '/media/com_contentintegrator/css',
+            JPATH_SITE . '/media/com_contentintegrator/js',
+            JPATH_SITE . '/media/com_contentintegrator/images',
+        ];
+
+        foreach ($paths as $path)
+        {
+            if (!is_dir($path))
+            {
+                \Joomla\CMS\Filesystem\Folder::create($path, 0755);
+            }
+        }
+
+        $missing = [];
+        $base    = __DIR__;
+
+        $xml = simplexml_load_file($base . '/com_contentintegrator.xml');
+
+        foreach ($xml->administration->files->filename as $file)
+        {
+            $abs = $base . '/' . (string) $file;
+
+            if (!is_file($abs))
+            {
+                $missing[] = $abs;
+            }
+        }
+
+        if ($missing)
+        {
+            Factory::getApplication()->enqueueMessage(
+                'Fehlende Dateien: ' . implode(', ', $missing),
+                'error'
+            );
+
+            return false;
+        }
+
+        $tmpFile = JPATH_ADMINISTRATOR . '/components/com_contentintegrator/test.tmp';
+
+        if (!@file_put_contents($tmpFile, 'test'))
+        {
+            Factory::getApplication()->enqueueMessage(
+                'Das Verzeichnis ' . dirname($tmpFile) . ' ist nicht beschreibbar.',
+                'error'
+            );
+
+            return false;
+        }
+
+        @unlink($tmpFile);
+
         $db = Factory::getDbo();
         $db->setQuery(
             'DELETE FROM #__extensions WHERE element = ' .


### PR DESCRIPTION
## Summary
- ensure manifest lists admin/sql and media images directories
- add preflight directory creation, file existence and permission tests

## Testing
- `php -l administrator/components/com_contentintegrator/script.php`
- `xmllint --noout administrator/components/com_contentintegrator/com_contentintegrator.xml`


------
https://chatgpt.com/codex/tasks/task_e_6892a814a56c83299b1f2cf4d214626a