### PR TITLE
Fix language file copy path in content integrator

### DIFF
--- a/administrator/components/com_contentintegrator/src/Model/ImportModel.php
+++ b/administrator/components/com_contentintegrator/src/Model/ImportModel.php
@@ -36,10 +36,10 @@ class ImportModel extends BaseDatabaseModel
             $ini = $dir . '/' . $code . '.com_contentintegrator.ini';
             $sys = $dir . '/' . $code . '.com_contentintegrator.sys.ini';
             if (!file_exists($ini)) {
-                File::copy(JPATH_ADMINISTRATOR . '/components/com_contentintegrator/language/en-GB/en-GB.com_contentintegrator.ini', $ini);
+                File::copy(JPATH_ADMINISTRATOR . '/language/en-GB/en-GB.com_contentintegrator.ini', $ini);
             }
             if (!file_exists($sys)) {
-                File::copy(JPATH_ADMINISTRATOR . '/components/com_contentintegrator/language/en-GB/en-GB.com_contentintegrator.sys.ini', $sys);
+                File::copy(JPATH_ADMINISTRATOR . '/language/en-GB/en-GB.com_contentintegrator.sys.ini', $sys);
             }
             Factory::getLanguage()->load('com_contentintegrator', JPATH_ADMINISTRATOR, $code, true, false);
             $languages[] = $code;


### PR DESCRIPTION
## Summary
- fix incorrect source path when copying default language files

## Testing
- `php -l administrator/components/com_contentintegrator/src/Model/ImportModel.php`
- `php verify_extension.php .`


------
https://chatgpt.com/codex/tasks/task_e_6892cb6721dc8329bcb3e012d732b242